### PR TITLE
fix: OpenAPI4j バージョンを1.0.8から1.0.7に修正し、API互換性を確保

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ node {
 
 // --- Optional: OpenAPI contract test wiring (enable with -PenableOpenApiContract) ---
 def enableOpenApiContract = project.hasProperty('enableOpenApiContract')
-def openapi4jVersion = '1.0.8'
+def openapi4jVersion = '1.0.7'
 
 configurations.configureEach { configuration ->
     if (configuration.name.startsWith('contractTest') || configuration.name.startsWith('test')) {

--- a/src/contractTest/java/com/example/teamdev/contract/OpenApiContractTest.java
+++ b/src/contractTest/java/com/example/teamdev/contract/OpenApiContractTest.java
@@ -50,15 +50,15 @@ class OpenApiContractTest extends com.example.teamdev.testconfig.PostgresContain
         // openapi4j: org.openapi4j.parser.OpenApi3Parser / model.v3.OpenApi3
         // 依存は contractTest のみが参照するため、通常ビルドや通常テストには影響しません
         org.openapi4j.parser.model.v3.OpenApi3 api = new org.openapi4j.parser.OpenApi3Parser()
-            .parse(tmp.toURI(), true);
+            .parse(tmp, true);
 
         assertThat(api).isNotNull();
         assertThat(api.getOpenapi()).isNotBlank();
 
         // 代表的なパスの存在を検証（細かなレスポンス検証は後続で OperationValidator を追加予定）
         assertThat(api.getPaths()).isNotNull();
-        assertThat(api.getPaths().getPath("/api/auth/session")).isNotNull();
-        assertThat(api.getPaths().getPath("/api/auth/login")).isNotNull();
+        assertThat(api.getPaths().get("/api/auth/session")).isNotNull();
+        assertThat(api.getPaths().get("/api/auth/login")).isNotNull();
     }
 }
 


### PR DESCRIPTION
問題:
- ./gradlew contractTest -PenableOpenApiContract 実行時に依存関係解決エラーが発生
- org.openapi4j:openapi-parser:1.0.8 がMaven Centralに存在しない
- org.openapi4j:openapi-operation-validator:1.0.8 がMaven Centralに存在しない

解決策:
1. build.gradle: openapi4jVersionを1.0.8から1.0.7に変更
   - Maven Centralで利用可能な最新バージョンに修正

2. OperationContractSupport.java: OpenAPI4j 1.0.7のAPIに対応
   - parse()メソッド: toURI()からFileオブジェクトに変更
   - validator()メソッド: PathとOperationオブジェクトを明示的に取得
   - ValidationData: org.openapi4j.schema.validatorパッケージから正しくインポート
   - Body.from(): JsonNodeをBodyオブジェクトに変換

3. OpenApiContractTest.java: OpenAPI4j 1.0.7のAPIに対応
   - parse()メソッド: toURI()からFileオブジェクトに変更
   - getPath(): Mapのget()メソッドを使用

検証:
- コンパイルエラーが解消されました
- 通常のテスト（./gradlew test）が成功
- ビルド（./gradlew build）が成功
- 契約テストのコンパイルが成功

注意:
- OpenAPI4jライブラリは2021年にアーカイブされ、メンテナンスされていません
- 将来的には代替ライブラリへの移行を検討することをお勧めします