### PR TITLE
Ensure OpenAPI responses use JSON and align stamp types

### DIFF
--- a/src/main/java/com/example/teamdev/controller/api/AuthRestController.java
+++ b/src/main/java/com/example/teamdev/controller/api/AuthRestController.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -47,7 +48,7 @@ public class AuthRestController {
     }
 
     @Operation(summary = "ログイン", description = "メールとパスワードでログインし、セッションを開始します")
-    @PostMapping("/login")
+    @PostMapping(value = "/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<LoginResponse> login(
         @Valid @RequestBody LoginRequest request,
         HttpServletRequest httpRequest,
@@ -72,7 +73,7 @@ public class AuthRestController {
     }
 
     @Operation(summary = "セッション状態取得", description = "現在の認証状態と従業員概要を返します")
-    @GetMapping("/session")
+    @GetMapping(value = "/session", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SessionResponse> session(CsrfToken csrfToken) {
         if (csrfToken != null) {
             csrfToken.getToken();

--- a/src/main/java/com/example/teamdev/controller/api/HomeRestController.java
+++ b/src/main/java/com/example/teamdev/controller/api/HomeRestController.java
@@ -6,6 +6,7 @@ import com.example.teamdev.dto.api.home.HomeDashboardResponse;
 import com.example.teamdev.dto.api.home.HomeNewsItem;
 import com.example.teamdev.dto.api.home.StampRequest;
 import com.example.teamdev.dto.api.home.StampResponse;
+import com.example.teamdev.dto.api.home.StampType;
 import com.example.teamdev.entity.Employee;
 import com.example.teamdev.form.HomeForm;
 import com.example.teamdev.service.HomeNewsService;
@@ -14,6 +15,7 @@ import com.example.teamdev.util.MessageUtil;
 import com.example.teamdev.util.SecurityUtil;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,7 +48,7 @@ public class HomeRestController {
     }
 
     @Operation(summary = "ホーム概要", description = "ログイン中の従業員情報とお知らせ一覧を返却")
-    @GetMapping("/overview")
+    @GetMapping(value = "/overview", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<HomeDashboardResponse> overview() {
         Employee currentEmployee = SecurityUtil.getCurrentEmployee();
         if (currentEmployee == null) {
@@ -62,7 +64,7 @@ public class HomeRestController {
     }
 
     @Operation(summary = "打刻", description = "出勤/退勤の打刻を記録")
-    @PostMapping("/stamps")
+    @PostMapping(value = "/stamps", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<StampResponse> stamp(@Valid @RequestBody StampRequest request) {
         Integer employeeId = SecurityUtil.getCurrentEmployeeId();
         if (employeeId == null) {
@@ -74,7 +76,7 @@ public class HomeRestController {
 
         LocalDateTime dateTime = LocalDateTime.parse(request.stampTime(), INPUT_FORMATTER);
         String formattedDateTime = dateTime.format(OUTPUT_FORMATTER);
-        String messageKey = request.stampType().equals(AppConstants.Stamp.TYPE_ATTENDANCE) ?
+        String messageKey = request.stampType() == StampType.ATTENDANCE ?
             "stamp.attendance.success" : "stamp.departure.success";
         String message = MessageUtil.getMessage(messageKey, new Object[]{formattedDateTime});
 

--- a/src/main/java/com/example/teamdev/controller/api/StampHistoryRestController.java
+++ b/src/main/java/com/example/teamdev/controller/api/StampHistoryRestController.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +30,7 @@ public class StampHistoryRestController {
     }
 
     @Operation(summary = "打刻履歴取得", description = "年・月の指定がなければ当月を返却")
-    @GetMapping
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<StampHistoryResponse> history(
         @RequestParam(value = "year", required = false) String year,
         @RequestParam(value = "month", required = false) String month

--- a/src/main/java/com/example/teamdev/dto/api/home/StampRequest.java
+++ b/src/main/java/com/example/teamdev/dto/api/home/StampRequest.java
@@ -2,10 +2,11 @@ package com.example.teamdev.dto.api.home;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record StampRequest(
     @Schema(description = "打刻種別", example = "ATTENDANCE")
-    @NotBlank String stampType,
+    @NotNull StampType stampType,
     @Schema(description = "打刻時刻(ISO)", example = "2025-01-01T09:00:00")
     @NotBlank String stampTime,
     @Schema(description = "深夜勤務フラグ", example = "0")

--- a/src/main/java/com/example/teamdev/dto/api/home/StampType.java
+++ b/src/main/java/com/example/teamdev/dto/api/home/StampType.java
@@ -1,0 +1,29 @@
+package com.example.teamdev.dto.api.home;
+
+import com.example.teamdev.constant.AppConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * API 上で使用する打刻種別。
+ */
+@Schema(description = "打刻種別", enumAsRef = true)
+public enum StampType {
+    /** 出勤 */
+    ATTENDANCE(AppConstants.LogHistory.OPERATION_ATTENDANCE),
+    /** 退勤 */
+    DEPARTURE(AppConstants.LogHistory.OPERATION_DEPARTURE);
+
+    private final int logHistoryOperationType;
+
+    StampType(int logHistoryOperationType) {
+        this.logHistoryOperationType = logHistoryOperationType;
+    }
+
+    /**
+     * ログ履歴登録で使用する操作種別 ID を返します。
+     */
+    public int getLogHistoryOperationType() {
+        return logHistoryOperationType;
+    }
+}
+

--- a/src/main/java/com/example/teamdev/form/HomeForm.java
+++ b/src/main/java/com/example/teamdev/form/HomeForm.java
@@ -1,6 +1,8 @@
 package com.example.teamdev.form;
 
+import com.example.teamdev.dto.api.home.StampType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,8 +22,8 @@ public class HomeForm {
 	/**
 	 * 打刻種別
 	 */
-	@NotBlank
-	private String stampType;
+        @NotNull
+        private StampType stampType;
 	/**
 	 * 夜勤フラグ
 	 */

--- a/src/main/java/com/example/teamdev/service/StampService.java
+++ b/src/main/java/com/example/teamdev/service/StampService.java
@@ -3,12 +3,13 @@ package com.example.teamdev.service;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.teamdev.constant.AppConstants;
+import com.example.teamdev.dto.api.home.StampType;
 import com.example.teamdev.entity.StampHistory;
 import com.example.teamdev.form.HomeForm;
 import com.example.teamdev.mapper.StampHistoryMapper;
@@ -21,41 +22,43 @@ import com.example.teamdev.mapper.StampHistoryMapper;
 @Transactional
 public class StampService {
 
-	@Autowired
-	StampHistoryMapper mapper;
-	@Autowired
-	    LogHistoryRegistrationService logHistoryService;
+    @Autowired
+    StampHistoryMapper mapper;
+    @Autowired
+    LogHistoryRegistrationService logHistoryService;
 
     public void execute(HomeForm homeForm, Integer employeeId) {
+        StampType stampType = homeForm.getStampType();
+        if (stampType == null) {
+            throw new IllegalArgumentException("Stamp type must be provided");
+        }
+        int nightWorkFlag = Integer.parseInt(homeForm.getNightWorkFlag());
 
-		int stampType = Integer.parseInt(homeForm.getStampType());
-		int nightWorkFlag = Integer.parseInt(homeForm.getNightWorkFlag());
+        //打刻時刻をTimestamp型に変換
+        //homeForm.getStampTime(): yyyy-MM-ddTHH:mm:ss
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        LocalDateTime dateTime = LocalDateTime.parse(homeForm.getStampTime(), formatter);
+        Timestamp stampTime = Timestamp.valueOf(dateTime);
 
-		//打刻時刻をTimestamp型に変換
-		//homeForm.getStampTime(): yyyy-MM-ddTHH:mm:ss
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-		LocalDateTime dateTime = LocalDateTime.parse(homeForm.getStampTime(), formatter);
-		Timestamp stampTime = Timestamp.valueOf(dateTime);
-
-		//DBに登録するため、年月日分割
-		Timestamp targetStampDate = stampTime;
-		//退勤かつ夜勤打刻チェックがある場合は日を前日とする
-		if (stampType == 2 && nightWorkFlag == 1) {
-			// stampTimeからLocalDateTimeを取得
-			LocalDateTime localDateTime = stampTime.toLocalDateTime();
-			// 前日の日付を計算
-			LocalDateTime previousDay = localDateTime.minusDays(1);
-			targetStampDate = Timestamp.valueOf(previousDay);
-		}
-		String targetTime = targetStampDate.toString();
-		// targetTime: yyyy-MM-dd　HH:mm:ss
-		// 空白文字を区切り文字として文字列を分割
-		String[] parts = targetTime.split("\\s+");
-		// 日付部分を "-" で分割して、年月日を取得
-		String[] dateParts = parts[0].split("-");
-		String year = dateParts[0];
-		String month = dateParts[1];
-		String day = dateParts[2];
+        //DBに登録するため、年月日分割
+        Timestamp targetStampDate = stampTime;
+        //退勤かつ夜勤打刻チェックがある場合は日を前日とする
+        if (stampType == StampType.DEPARTURE && nightWorkFlag == 1) {
+            // stampTimeからLocalDateTimeを取得
+            LocalDateTime localDateTime = stampTime.toLocalDateTime();
+            // 前日の日付を計算
+            LocalDateTime previousDay = localDateTime.minusDays(1);
+            targetStampDate = Timestamp.valueOf(previousDay);
+        }
+        String targetTime = targetStampDate.toString();
+        // targetTime: yyyy-MM-dd　HH:mm:ss
+        // 空白文字を区切り文字として文字列を分割
+        String[] parts = targetTime.split("\\s+");
+        // 日付部分を "-" で分割して、年月日を取得
+        String[] dateParts = parts[0].split("-");
+        String year = dateParts[0];
+        String month = dateParts[1];
+        String day = dateParts[2];
 
         StampHistory entity = new StampHistory();
         entity.setYear(year);
@@ -63,9 +66,9 @@ public class StampService {
         entity.setDay(day);
         entity.setEmployeeId(employeeId);
 
-        if (stampType == 1) {
+        if (stampType == StampType.ATTENDANCE) {
             entity.setInTime(stampTime);
-        } else if (stampType == 2) {
+        } else if (stampType == StampType.DEPARTURE) {
             entity.setOutTime(stampTime);
         }
 
@@ -96,6 +99,13 @@ public class StampService {
             mapper.save(entity);
         }
 
-        logHistoryService.execute(1, stampType, stampTime, employeeId, employeeId, date);
+        logHistoryService.execute(
+            AppConstants.LogHistory.FUNCTION_STAMP,
+            stampType.getLogHistoryOperationType(),
+            stampTime,
+            employeeId,
+            employeeId,
+            date
+        );
     }
 }

--- a/src/test/java/com/example/teamdev/service/StampServiceTest.java
+++ b/src/test/java/com/example/teamdev/service/StampServiceTest.java
@@ -1,9 +1,10 @@
 package com.example.teamdev.service;
 
-import com.example.teamdev.constant.AppConstants;
 import com.example.teamdev.entity.StampHistory;
 import com.example.teamdev.form.HomeForm;
 import com.example.teamdev.mapper.StampHistoryMapper;
+import com.example.teamdev.constant.AppConstants;
+import com.example.teamdev.dto.api.home.StampType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,7 @@ public class StampServiceTest {
 
     @Test
     void execute_shouldSaveNewAttendanceStamp() {
-        homeForm.setStampType(AppConstants.Stamp.TYPE_ATTENDANCE); // 出勤
+        homeForm.setStampType(StampType.ATTENDANCE); // 出勤
         homeForm.setNightWorkFlag(AppConstants.Stamp.NIGHT_WORK_FLAG_OFF); // 夜勤ではない
 
         stampService.execute(homeForm, employeeId);
@@ -67,13 +68,18 @@ public class StampServiceTest {
         assertNotNull(capturedStamp.getUpdateDate());
 
         verify(logHistoryService, times(1)).execute(
-                eq(1), eq(1), any(Timestamp.class), eq(employeeId), eq(employeeId), any(Timestamp.class)
+                eq(AppConstants.LogHistory.FUNCTION_STAMP),
+                eq(StampType.ATTENDANCE.getLogHistoryOperationType()),
+                any(Timestamp.class),
+                eq(employeeId),
+                eq(employeeId),
+                any(Timestamp.class)
         );
     }
 
     @Test
     void execute_shouldSaveNewLeaveStamp() {
-        homeForm.setStampType(AppConstants.Stamp.TYPE_DEPARTURE); // 退勤
+        homeForm.setStampType(StampType.DEPARTURE); // 退勤
         homeForm.setNightWorkFlag(AppConstants.Stamp.NIGHT_WORK_FLAG_OFF); // 夜勤ではない
 
         stampService.execute(homeForm, employeeId);
@@ -92,7 +98,12 @@ public class StampServiceTest {
         assertNotNull(capturedStamp.getUpdateDate());
 
         verify(logHistoryService, times(1)).execute(
-                eq(1), eq(2), any(Timestamp.class), eq(employeeId), eq(employeeId), any(Timestamp.class)
+                eq(AppConstants.LogHistory.FUNCTION_STAMP),
+                eq(StampType.DEPARTURE.getLogHistoryOperationType()),
+                any(Timestamp.class),
+                eq(employeeId),
+                eq(employeeId),
+                any(Timestamp.class)
         );
     }
 
@@ -101,7 +112,7 @@ public class StampServiceTest {
         // 翌日午前2時の退勤を想定
         LocalDateTime nightLeaveTime = LocalDateTime.of(2025, 7, 11, 2, 0, 0);
         homeForm.setStampTime(nightLeaveTime.format(DateTimeFormatter.ofPattern(AppConstants.DateFormat.ISO_LOCAL_DATE_TIME)));
-        homeForm.setStampType(AppConstants.Stamp.TYPE_DEPARTURE); // 退勤
+        homeForm.setStampType(StampType.DEPARTURE); // 退勤
         homeForm.setNightWorkFlag(AppConstants.Stamp.NIGHT_WORK_FLAG_ON); // 夜勤
 
         stampService.execute(homeForm, employeeId);
@@ -122,7 +133,12 @@ public class StampServiceTest {
         assertNotNull(capturedStamp.getUpdateDate());
 
         verify(logHistoryService, times(1)).execute(
-                eq(1), eq(2), any(Timestamp.class), eq(employeeId), eq(employeeId), any(Timestamp.class)
+                eq(AppConstants.LogHistory.FUNCTION_STAMP),
+                eq(StampType.DEPARTURE.getLogHistoryOperationType()),
+                any(Timestamp.class),
+                eq(employeeId),
+                eq(employeeId),
+                any(Timestamp.class)
         );
     }
 
@@ -132,7 +148,7 @@ public class StampServiceTest {
     void execute_shouldCallSaveEvenIfRecordMightExist() {
         // このテストは、ロジック変更により getStampHistoryByYearMonthDayEmployeeId が呼び出されなくなったことを確認する
         // 以前のロジックでは、ここで mapper.getStampHistoryByYearMonthDayEmployeeId が呼び出されていた
-        homeForm.setStampType(AppConstants.Stamp.TYPE_ATTENDANCE); // 出勤
+        homeForm.setStampType(StampType.ATTENDANCE); // 出勤
         homeForm.setNightWorkFlag(AppConstants.Stamp.NIGHT_WORK_FLAG_OFF); // 夜勤ではない
 
         stampService.execute(homeForm, employeeId);


### PR DESCRIPTION
## Summary
- declare explicit JSON request/response media types on the auth, home, and stamp history controllers so the generated OpenAPI matches the contract tests
- introduce a StampType enum and thread it through the home stamping flow to accept symbolic values while keeping existing log-history semantics
- update the stamping service and tests to consume the new enum and continue logging the correct operations

## Testing
- ./gradlew compileJava
- ./gradlew contractTest -PenableOpenApiContract *(fails: Maven Central returned HTTP 403 when downloading test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4745de3608322b02aa1b434cd065a