### PR TITLE
fix: align session response with openapi contract

### DIFF
--- a/src/main/java/com/example/teamdev/dto/api/auth/SessionResponse.java
+++ b/src/main/java/com/example/teamdev/dto/api/auth/SessionResponse.java
@@ -1,8 +1,10 @@
 package com.example.teamdev.dto.api.auth;
 
 import com.example.teamdev.dto.api.common.EmployeeSummaryResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SessionResponse(
     boolean authenticated,
     @Schema(nullable = true) EmployeeSummaryResponse employee

--- a/src/test/java/com/example/teamdev/integration/AuthRestControllerIntegrationTest.java
+++ b/src/test/java/com/example/teamdev/integration/AuthRestControllerIntegrationTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -61,7 +60,7 @@ class AuthRestControllerIntegrationTest extends PostgresContainerSupport {
         mockMvc.perform(get("/api/auth/session"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.authenticated").value(false))
-            .andExpect(jsonPath("$.employee", nullValue()));
+            .andExpect(jsonPath("$.employee").doesNotExist());
     }
 
     @DisplayName("Successful login returns employee summary and persists session")

--- a/src/test/java/com/example/teamdev/integration/LoginFlowIntegrationTest.java
+++ b/src/test/java/com/example/teamdev/integration/LoginFlowIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -63,7 +62,7 @@ class LoginFlowIntegrationTest extends PostgresContainerSupport {
             mockMvc.perform(get("/api/auth/session"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.authenticated").value(false))
-                .andExpect(jsonPath("$.employee", nullValue()));
+                .andExpect(jsonPath("$.employee").doesNotExist());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- avoid serializing the session employee payload when it is null so the response matches the OpenAPI schema
- adjust authentication integration tests to expect the employee field to be omitted for anonymous sessions

## Testing
- ./gradlew test
- ./gradlew contractTest -PenableOpenApiContract

> Droid-assisted change