### PR TITLE
Fix navigation suspending and standardize auth redirect path

### DIFF
--- a/frontend/src/app/config/enhanced-query-client.test.ts
+++ b/frontend/src/app/config/enhanced-query-client.test.ts
@@ -106,7 +106,7 @@ describe("Enhanced Query Client", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(mockOnLogout).toHaveBeenCalled();
-      expect(mockOnRedirect).toHaveBeenCalledWith("/auth/signin");
+      expect(mockOnRedirect).toHaveBeenCalledWith("/signin");
       // 認証エラーではToastを表示しない
       expect(mockToast).not.toHaveBeenCalled();
     });

--- a/frontend/src/app/config/enhanced-query-client.ts
+++ b/frontend/src/app/config/enhanced-query-client.ts
@@ -145,7 +145,7 @@ const handleQueryError = (error: unknown, config: QueryClientConfig): void => {
           console.warn("Logout error during auth error handling:", logoutError);
         }
       }
-      const loginPath = config.loginPath || "/auth/signin";
+      const loginPath = config.loginPath || "/signin";
       config.onRedirect?.(loginPath);
     };
 

--- a/frontend/src/app/config/error-interceptor.ts
+++ b/frontend/src/app/config/error-interceptor.ts
@@ -43,7 +43,7 @@ export const handle401Error = async (
     }
 
     // ログインページへリダイレクト
-    const loginPath = config.loginPath ?? "/auth/signin";
+    const loginPath = config.loginPath ?? "/signin";
     config.onRedirect(loginPath);
   }
 };

--- a/frontend/src/app/config/queryClient.ts
+++ b/frontend/src/app/config/queryClient.ts
@@ -76,11 +76,12 @@ export const queryClient = createQueryClient();
  */
 export const configureQueryClientErrorHandler = (
   logout: () => Promise<void>,
-  redirect: (path: string) => void
+  redirect: (path: string) => void,
+  loginPath = "/signin"
 ): void => {
   globalErrorHandler = createGlobalErrorHandler({
     onLogout: logout,
     onRedirect: redirect,
-    loginPath: "/auth/signin",
+    loginPath,
   });
 };

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -2,7 +2,7 @@ import "@/styles/global.css";
 
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { lazy, StrictMode, useEffect } from "react";
+import { lazy, StrictMode, Suspense, useEffect } from "react";
 import {
   createBrowserRouter,
   Outlet,
@@ -22,6 +22,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { SessionTimeoutNotification } from "@/features/auth/components/SessionTimeoutNotification";
 import { AuthProvider } from "@/features/auth/context/AuthProvider";
 import { IconSpriteSheet } from "@/shared/components/icons/SpriteIcon";
+import { PageLoader } from "@/shared/components/layout/PageLoader";
 
 // Lazy load route components for code splitting
 const SignInRoute = lazy(() =>
@@ -178,7 +179,9 @@ export const AppProviders = () => (
     <IconSpriteSheet />
     <ThemeProvider defaultTheme="system" disablePersistence>
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <Suspense fallback={<PageLoader label="画面を読み込み中" />}>
+          <RouterProvider router={router} />
+        </Suspense>
         {import.meta.env.DEV &&
         import.meta.env["VITE_DISABLE_DATA_TABLE_VIEW_OPTIONS"] !== "true" ? (
           <ReactQueryDevtools initialIsOpen={false} />

--- a/frontend/src/features/auth/context/AuthProvider.tsx
+++ b/frontend/src/features/auth/context/AuthProvider.tsx
@@ -44,7 +44,7 @@ const defaultConfig: AuthProviderConfig = {
     warningBeforeExpiry: WARNING_THRESHOLD_MINUTES,
     autoExtendSession: false,
   },
-  loginPath: "/auth/signin",
+  loginPath: "/signin",
   defaultRedirectPath: "/",
 };
 
@@ -193,8 +193,12 @@ export const AuthProvider = ({ children, config }: AuthProviderProps) => {
     // ESLintのno-misused-promisesルールを回避
     // handleLogoutは非同期関数だが、エラーハンドラー内で適切に処理される
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    configureQueryClientErrorHandler(handleLogout, navigate);
-  }, [navigate, handleLogout]);
+    configureQueryClientErrorHandler(
+      handleLogout,
+      navigate,
+      mergedConfig.loginPath
+    );
+  }, [navigate, handleLogout, mergedConfig.loginPath]);
 
   // セッション変更の監視
   useEffect(() => {

--- a/frontend/src/features/home/components/HomePage.test.tsx
+++ b/frontend/src/features/home/components/HomePage.test.tsx
@@ -124,7 +124,7 @@ describe("HomePage", () => {
 
       const cachedQuery = queryClient
         .getQueryCache()
-        .find({ queryKey: ["home", "overview"] });
+        .find({ queryKey: ["home", "dashboard"] });
 
       const cachedOptions = cachedQuery?.options as
         | {

--- a/frontend/src/shared/api/errors/AuthenticationError.ts
+++ b/frontend/src/shared/api/errors/AuthenticationError.ts
@@ -7,7 +7,7 @@ import { ApiError } from "./ApiError";
 export class AuthenticationError extends ApiError {
   readonly redirectTo?: string;
 
-  constructor(message = "Unauthorized", redirectTo = "/auth/signin") {
+  constructor(message = "Unauthorized", redirectTo = "/signin") {
     super(message, 401, "AUTHENTICATION_ERROR");
     this.redirectTo = redirectTo;
 
@@ -31,7 +31,7 @@ export class AuthenticationError extends ApiError {
    * リダイレクト先のパスを取得
    */
   getRedirectPath(): string {
-    return this.redirectTo || "/auth/signin";
+    return this.redirectTo || "/signin";
   }
 
   /**

--- a/frontend/src/shared/error-handling/integration.test.tsx
+++ b/frontend/src/shared/error-handling/integration.test.tsx
@@ -238,7 +238,7 @@ describe("Error Handling System Integration", () => {
       // ログアウトとリダイレクトが呼ばれたことを確認
       await waitFor(() => {
         expect(mockOnLogout).toHaveBeenCalled();
-        expect(mockOnRedirect).toHaveBeenCalledWith("/auth/signin");
+        expect(mockOnRedirect).toHaveBeenCalledWith("/signin");
       });
 
       // 認証エラーではToastを表示しない


### PR DESCRIPTION
Summary
Wrapped the application router in a Suspense fallback so lazy–loaded routes render immediately with a consistent loader, eliminating the sidebar navigation lag.
Standardized all authentication redirects to use /signin, wiring the path through AuthProvider, the query-client error handler, interceptors, and associated tests to keep sign-out flows and global 401 handling in sync.
Realigned the home dashboard cache test to the current query key, ensuring coverage of the staleTime configuration.
Testing
npm run lint
npm run typecheck
npm run test (suite passes; MSW still logs feature-flag handler warnings)
npm run build (succeeds; Vite notes that Node.js 20.19+ is recommended)