### PR TITLE
feat: improve attendance and navigation ux

### DIFF
--- a/frontend/src/app/layouts/AppLayout.tsx
+++ b/frontend/src/app/layouts/AppLayout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { AppHeader } from "@/shared/components/layout/AppHeader";
 import { AppShell } from "@/shared/components/layout/AppShell";
 import { AppSidebar } from "@/shared/components/layout/AppSidebar";
+import { NavigationProgress } from "@/shared/components/layout/NavigationProgress";
 import { PageLoader } from "@/shared/components/layout/PageLoader";
 
 export const AppLayout = () => {
@@ -31,17 +32,20 @@ export const AppLayout = () => {
   }
 
   return (
-    <AppShell>
-      {/* デスクトップ用サイドバー */}
-      <AppSidebar className="hidden lg:block" />
+    <>
+      <NavigationProgress />
+      <AppShell>
+        {/* デスクトップ用サイドバー */}
+        <AppSidebar className="hidden lg:block" />
 
-      {/* メインコンテンツエリア */}
-      <div className="flex min-h-screen flex-col lg:min-h-0">
-        <AppHeader />
-        <main className="flex-1 overflow-y-auto p-4 lg:p-6">
-          <Outlet />
-        </main>
-      </div>
-    </AppShell>
+        {/* メインコンテンツエリア */}
+        <div className="flex min-h-screen flex-col lg:min-h-0">
+          <AppHeader />
+          <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+            <Outlet />
+          </main>
+        </div>
+      </AppShell>
+    </>
   );
 };

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -43,6 +43,12 @@ const HomeRoute = lazy(() =>
   }))
 );
 
+const AttendanceRoute = lazy(() =>
+  import("@/features/home/routes/AttendanceRoute").then((module) => ({
+    default: module.AttendanceRoute,
+  }))
+);
+
 const StampHistoryRoute = lazy(() =>
   import("@/features/stampHistory/routes/StampHistoryRoute").then((module) => ({
     default: module.StampHistoryRoute,
@@ -127,7 +133,7 @@ const router = createBrowserRouter([
           },
           {
             path: "attendance",
-            element: <HomeRoute />,
+            element: <AttendanceRoute />,
             loader: () => homeRouteLoader(queryClient),
           },
           {

--- a/frontend/src/features/employees/components/EmployeeListPage.tsx
+++ b/frontend/src/features/employees/components/EmployeeListPage.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import { AlertCircle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { PageLoader } from "@/shared/components/layout/PageLoader";
@@ -35,7 +38,13 @@ export function EmployeeListPage() {
   const { toast } = useToast();
 
   // データフェッチング
-  const { data, isLoading, isError } = useEmployees();
+  const { data, isLoading, isError, error, refetch } = useEmployees();
+
+  const handleRetry = () => {
+    refetch().catch(() => {
+      // 追加のエラーハンドリングは不要
+    });
+  };
 
   // Mutations
   const createMutation = useCreateEmployee();
@@ -166,20 +175,29 @@ export function EmployeeListPage() {
   };
 
   // ローディング状態
-  if (isLoading || !data) {
+  if (isLoading) {
     return <PageLoader label="従業員情報を読み込み中" />;
   }
 
   // エラー状態
-  if (isError) {
+  if (isError || !data) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <h2 className="mb-4 font-bold text-2xl">エラーが発生しました</h2>
-          <p className="text-muted-foreground">
-            従業員情報の読み込みに失敗しました
-          </p>
-        </div>
+      <div className="flex h-full flex-col items-center justify-center gap-4 px-4">
+        <Alert
+          className="w-full max-w-xl border-red-200 bg-red-50 text-red-700"
+          variant="destructive"
+        >
+          <AlertCircle aria-hidden className="h-5 w-5" />
+          <AlertTitle>従業員情報の取得に失敗しました</AlertTitle>
+          <AlertDescription>
+            {error instanceof Error
+              ? error.message
+              : "時間をおいて再度お試しください。"}
+          </AlertDescription>
+        </Alert>
+        <Button onClick={handleRetry} variant="outline">
+          再読み込み
+        </Button>
       </div>
     );
   }

--- a/frontend/src/features/home/components/AttendancePage.tsx
+++ b/frontend/src/features/home/components/AttendancePage.tsx
@@ -1,0 +1,73 @@
+import { AlertCircle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { PageLoader } from "@/shared/components/layout/PageLoader";
+
+import { useDashboard } from "../hooks/useDashboard";
+import { useStamp } from "../hooks/useStamp";
+import { StampCard } from "./StampCard";
+
+export const AttendancePage = () => {
+  const { data, isLoading, isError, error, refetch } = useDashboard();
+  const {
+    handleStamp,
+    isLoading: isStamping,
+    message,
+    clearMessage,
+  } = useStamp();
+
+  const handleRetry = () => {
+    refetch().catch(() => {
+      // リカバリー用の追加処理は不要
+    });
+  };
+
+  if (isLoading) {
+    return <PageLoader label="出退勤情報を読み込み中" />;
+  }
+
+  if (isError || !data) {
+    return (
+      <section className="container mx-auto flex h-full max-w-4xl flex-1 flex-col items-center justify-center gap-4 px-4 py-6">
+        <Alert
+          className="w-full max-w-xl border-red-200 bg-red-50 text-red-700"
+          variant="destructive"
+        >
+          <AlertCircle aria-hidden className="h-5 w-5" />
+          <AlertTitle>出退勤情報を取得できませんでした</AlertTitle>
+          <AlertDescription>
+            {error instanceof Error
+              ? error.message
+              : "通信状況をご確認のうえ、再度お試しください。"}
+          </AlertDescription>
+        </Alert>
+        <Button onClick={handleRetry} variant="outline">
+          再読み込み
+        </Button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="container mx-auto max-w-4xl space-y-6 px-4 py-6">
+      <header className="space-y-2">
+        <p className="text-sm font-medium text-blue-600">出退勤</p>
+        <h1 className="font-bold text-3xl text-slate-900 tracking-tight">
+          ワンクリックで打刻を記録
+        </h1>
+        <p className="text-slate-600">
+          {data.employee.lastName} {data.employee.firstName}{" "}さん、本日の打刻状況を確認してから操作してください。
+        </p>
+      </header>
+
+      <StampCard
+        autoDismissDelay={6000}
+        isLoading={isStamping}
+        message={message}
+        onDismissMessage={clearMessage}
+        onStamp={handleStamp}
+      />
+    </section>
+  );
+};

--- a/frontend/src/features/home/components/HomePageRefactored.tsx
+++ b/frontend/src/features/home/components/HomePageRefactored.tsx
@@ -1,3 +1,7 @@
+import { AlertCircle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { PageLoader } from "@/shared/components/layout/PageLoader";
 
 import { useDashboard } from "../hooks/useDashboard";
@@ -11,25 +15,56 @@ import { StampCard } from "./StampCard";
  * Dependency Inversion: カスタムフックのインターフェースに依存
  */
 export const HomePageRefactored = () => {
-  const { data, isLoading } = useDashboard();
-  const { handleStamp, isLoading: isStamping, message } = useStamp();
+  const { data, isLoading, isError, error, refetch } = useDashboard();
+  const { handleStamp, isLoading: isStamping, message, clearMessage } =
+    useStamp();
 
-  if (isLoading || !data) {
+  const handleRetry = () => {
+    refetch().catch(() => {
+      // 再試行時の追加処理は不要
+    });
+  };
+
+  if (isLoading) {
     return <PageLoader label="ダッシュボードを読み込み中" />;
   }
 
+  if (isError || !data) {
+    return (
+      <section className="container mx-auto flex h-full max-w-5xl flex-1 flex-col items-center justify-center gap-4 px-4 py-6">
+        <Alert
+          className="w-full max-w-xl border-red-200 bg-red-50 text-red-700"
+          variant="destructive"
+        >
+          <AlertCircle aria-hidden className="h-5 w-5" />
+          <AlertTitle>ダッシュボードを読み込めませんでした</AlertTitle>
+          <AlertDescription>
+            {error instanceof Error
+              ? error.message
+              : "時間をおいて再度お試しください。"}
+          </AlertDescription>
+        </Alert>
+        <Button onClick={handleRetry} variant="outline">
+          再読み込み
+        </Button>
+      </section>
+    );
+  }
+
   return (
-    <section className="home container mx-auto px-4 py-6">
+    <section className="home container mx-auto max-w-5xl px-4 py-6">
       <HomeHero
         firstName={data.employee.firstName}
         lastName={data.employee.lastName}
       />
 
-      <div className="home-grid grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div className="home-grid grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <StampCard
+          autoDismissDelay={6000}
           className="home-card"
           isLoading={isStamping}
           message={message}
+          onDismissMessage={clearMessage}
           onStamp={handleStamp}
         />
         <NewsCard

--- a/frontend/src/features/home/components/NewsCard.tsx
+++ b/frontend/src/features/home/components/NewsCard.tsx
@@ -31,8 +31,8 @@ export const NewsCard = memo(
       if (isLoading) {
         return (
           <div className="space-y-3">
+            <Skeleton className="h-4 w-2/5" />
             <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-4 w-full" />
             <Skeleton className="h-4 w-5/6" />
           </div>
         );
@@ -40,7 +40,7 @@ export const NewsCard = memo(
 
       if (newsItems.length === 0) {
         return (
-          <CardDescription className="py-8 text-center text-muted-foreground">
+          <CardDescription className="py-8 text-center text-slate-500">
             現在表示できるお知らせはありません。
           </CardDescription>
         );
@@ -49,15 +49,18 @@ export const NewsCard = memo(
       return (
         <ul className="space-y-4">
           {newsItems.map((news) => (
-            <li className="border-b pb-3 last:border-0 last:pb-0" key={news.id}>
+            <li
+              className="border-slate-200/80 border-b pb-3 last:border-0 last:pb-0"
+              key={news.id}
+            >
               <div className="space-y-1">
                 <time
-                  className="text-neutral-500 text-xs"
+                  className="text-slate-500 text-xs"
                   dateTime={news.newsDate}
                 >
                   {news.newsDate}
                 </time>
-                <p className="text-neutral-900 text-sm leading-relaxed">
+                <p className="text-slate-700 text-sm leading-relaxed">
                   {news.content}
                 </p>
               </div>
@@ -68,11 +71,20 @@ export const NewsCard = memo(
     };
 
     return (
-      <Card className={cn("w-full", className)}>
+      <Card
+        className={cn(
+          "w-full border border-slate-200/80 bg-white shadow-sm transition-shadow hover:shadow-md",
+          className
+        )}
+      >
         <CardHeader>
-          <CardTitle className="text-lg">最新のお知らせ</CardTitle>
+          <CardTitle className="font-semibold text-lg text-slate-900">
+            最新のお知らせ
+          </CardTitle>
         </CardHeader>
-        <CardContent>{renderContent()}</CardContent>
+        <CardContent className="space-y-2 text-slate-600 text-sm">
+          {renderContent()}
+        </CardContent>
       </Card>
     );
   }

--- a/frontend/src/features/home/routes/AttendanceRoute.tsx
+++ b/frontend/src/features/home/routes/AttendanceRoute.tsx
@@ -1,0 +1,8 @@
+import { AttendancePage } from "@/features/home/components/AttendancePage";
+import { PageSuspenseWrapper } from "@/shared/components/loading/SuspenseWrapper";
+
+export const AttendanceRoute = () => (
+  <PageSuspenseWrapper>
+    <AttendancePage />
+  </PageSuspenseWrapper>
+);

--- a/frontend/src/shared/components/layout/NavigationProgress.tsx
+++ b/frontend/src/shared/components/layout/NavigationProgress.tsx
@@ -1,0 +1,51 @@
+import { useIsFetching } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigation } from "react-router-dom";
+
+import { cn } from "@/shared/utils/cn";
+
+const HIDE_DELAY = 250;
+
+export const NavigationProgress = () => {
+  const navigation = useNavigation();
+  const isFetching = useIsFetching();
+  const [isMounted, setIsMounted] = useState(false);
+
+  const isActive = navigation.state === "loading" || isFetching > 0;
+
+  useEffect(() => {
+    if (isActive) {
+      setIsMounted(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setIsMounted(false);
+    }, HIDE_DELAY);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isActive]);
+
+  const wrapperClassName = useMemo(
+    () =>
+      cn(
+        "pointer-events-none fixed inset-x-0 top-0 z-[70] flex justify-center transition-opacity duration-300",
+        isActive ? "opacity-100" : "opacity-0"
+      ),
+    [isActive]
+  );
+
+  if (!(isMounted || isActive)) {
+    return null;
+  }
+
+  return (
+    <div aria-hidden className={wrapperClassName}>
+      <div className="mx-4 mt-2 h-1 w-full max-w-5xl overflow-hidden rounded-full bg-blue-100/80 shadow-sm">
+        <div className="navigation-progress-bar h-full w-1/3 min-w-[120px] bg-blue-600" />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -140,6 +140,10 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+.navigation-progress-bar {
+  animation: progress-slide 1.2s ease-in-out infinite;
+}
+
 .not-found {
   text-align: center;
   display: grid;
@@ -158,6 +162,18 @@ body {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes progress-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(-15%);
+  }
+  100% {
+    transform: translateX(120%);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated attendance route and page with improved error handling and messaging for stamping
- enhance home dashboard cards for better contrast, loading feedback, and auto dismissal of stamp results
- introduce a global navigation progress indicator and improve employee admin error states

## Testing
- npm run lint --prefix frontend *(fails: existing Biome violations in unrelated files such as e2e/navigation-performance.spec.ts and src/features/auth/context/AuthProvider.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e60ea233408322be8b0cf5a5afb35c