### PR TITLE
fix: reapply themed component styles

### DIFF
--- a/frontend/src/features/auth/context/AuthProvider.tsx
+++ b/frontend/src/features/auth/context/AuthProvider.tsx
@@ -221,14 +221,15 @@ export const AuthProvider = ({ children, config }: AuthProviderProps) => {
 
   // セッションデータの初期化
   useEffect(() => {
-    if (sessionQuery.data?.authenticated && sessionQuery.data.employee) {
-      sessionManager.setSession(sessionQuery.data.employee);
+    const sessionData = sessionQuery.data;
+    if (sessionData?.authenticated && sessionData.employee) {
+      sessionManager.setSession(sessionData.employee);
 
-      const sessionData = sessionManager.getSession();
-      if (sessionData) {
+      const activeSession = sessionManager.getSession();
+      if (activeSession) {
         setSessionInfo({
-          createdAt: sessionData.createdAt,
-          expiresAt: sessionData.expiresAt,
+          createdAt: activeSession.createdAt,
+          expiresAt: activeSession.expiresAt,
           lastActivity: new Date(),
           warningThreshold: warningBeforeExpiry,
         });

--- a/frontend/src/features/home/components/StampCard.tsx
+++ b/frontend/src/features/home/components/StampCard.tsx
@@ -44,7 +44,7 @@ export const StampCard = memo(
       <Card className={cn("w-full", className)}>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="text-lg text-neutral-900">
+            <CardTitle className="text-lg text-foreground">
               ワンクリック打刻
             </CardTitle>
             <div className="flex items-center space-x-2">
@@ -56,7 +56,7 @@ export const StampCard = memo(
                 onCheckedChange={(checked) => setNightWork(checked === true)}
               />
               <label
-                className="font-medium text-neutral-900 text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                className="font-medium text-foreground text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 htmlFor="nightwork"
               >
                 夜勤扱い

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,14 +1,88 @@
 @import "tailwindcss";
 
+@theme {
+  --font-sans: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  --color-background: #f8fafc;
+  --color-foreground: #0f172a;
+
+  --color-card: #ffffff;
+  --color-card-foreground: #0f172a;
+
+  --color-popover: #ffffff;
+  --color-popover-foreground: #0f172a;
+
+  --color-primary: #1d4ed8;
+  --color-primary-foreground: #f8fafc;
+
+  --color-secondary: #e2e8f0;
+  --color-secondary-foreground: #1f2937;
+
+  --color-muted: #e2e8f0;
+  --color-muted-foreground: #475569;
+
+  --color-accent: #dbeafe;
+  --color-accent-foreground: #1d4ed8;
+
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #fef2f2;
+
+  --color-success: #15803d;
+  --color-success-foreground: #ecfdf5;
+
+  --color-border: #cbd5ff;
+  --color-input: #cbd5ff;
+  --color-ring: #1d4ed8;
+
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+}
+
+@theme dark {
+  --color-background: #0b1220;
+  --color-foreground: #e2e8f0;
+
+  --color-card: #111827;
+  --color-card-foreground: #f8fafc;
+
+  --color-popover: #111827;
+  --color-popover-foreground: #f8fafc;
+
+  --color-primary: #60a5fa;
+  --color-primary-foreground: #0b1220;
+
+  --color-secondary: #1f2937;
+  --color-secondary-foreground: #f8fafc;
+
+  --color-muted: #1c2536;
+  --color-muted-foreground: #94a3b8;
+
+  --color-accent: #1e3a8a;
+  --color-accent-foreground: #dbeafe;
+
+  --color-destructive: #f87171;
+  --color-destructive-foreground: #450a0a;
+
+  --color-success: #22c55e;
+  --color-success-foreground: #052e16;
+
+  --color-border: #1f2937;
+  --color-input: #1f2937;
+  --color-ring: #60a5fa;
+}
+
 :root {
   color-scheme: light;
-  font-family:
-    "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  font-family: var(--font-sans);
   line-height: 1.5;
   font-weight: 400;
-  background-color: #f6f8fa;
-  color: #0f172a;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
+.dark {
+  color-scheme: dark;
 }
 
 * {
@@ -18,17 +92,21 @@
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 .app-shell {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 .app-header {
-  background-color: #1d4ed8;
-  color: #ffffff;
+  background-color: var(--color-primary);
+  color: var(--color-primary-foreground);
   padding: 1rem 2rem;
   box-shadow: 0 1px 4px rgba(15, 23, 42, 0.2);
 }
@@ -57,18 +135,18 @@ body {
 }
 
 .nav-link {
-  color: #bfdbfe;
+  color: color-mix(in srgb, var(--color-primary-foreground) 70%, transparent);
   text-decoration: none;
   font-weight: 500;
 }
 
 .nav-link:hover,
 .nav-link:focus {
-  color: #ffffff;
+  color: var(--color-primary-foreground);
 }
 
 .nav-link--active {
-  color: #ffffff;
+  color: var(--color-primary-foreground);
   border-bottom: 2px solid #facc15;
 }
 
@@ -82,8 +160,8 @@ body {
 .home-hero {
   background: linear-gradient(
     135deg,
-    rgba(221, 243, 255, 1) 0%,
-    rgba(191, 219, 254, 1) 100%
+    color-mix(in srgb, var(--color-accent) 65%, white 35%) 0%,
+    var(--color-accent) 100%
   );
   border-radius: 1rem;
   padding: 3rem;
@@ -98,15 +176,15 @@ body {
 
 .home-hero__subtitle {
   font-size: clamp(1rem, 3vw, 1.25rem);
-  color: #1e293b;
+  color: var(--color-muted-foreground);
 }
 
 .button {
   appearance: none;
   border: none;
   border-radius: 999px;
-  background-color: #1d4ed8;
-  color: #ffffff;
+  background-color: var(--color-primary);
+  color: var(--color-primary-foreground);
   padding: 0.75rem 1.5rem;
   font-weight: 600;
   cursor: pointer;
@@ -135,8 +213,8 @@ body {
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  border: 3px solid rgba(59, 130, 246, 0.3);
-  border-top-color: rgba(29, 78, 216, 1);
+  border: 3px solid color-mix(in srgb, var(--color-primary) 30%, transparent);
+  border-top-color: var(--color-primary);
   animation: spin 0.8s linear infinite;
 }
 
@@ -152,7 +230,7 @@ body {
 }
 
 .not-found__description {
-  color: #1f2937;
+  color: var(--color-muted-foreground);
 }
 
 @keyframes spin {
@@ -165,9 +243,12 @@ body {
   margin: 4rem auto;
   width: min(100%, 420px);
   padding: 2.5rem 2rem;
-  border-radius: 1rem;
-  background-color: #ffffff;
-  box-shadow: 0 25px 50px -20px rgba(30, 64, 175, 0.35);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
+  box-shadow:
+    0 25px 50px -20px color-mix(in srgb, var(--color-primary) 35%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 65%, transparent);
   display: grid;
   gap: 1.25rem;
 }
@@ -186,28 +267,30 @@ body {
 
 .auth-card__label {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-foreground);
 }
 
 .auth-card__input {
   width: 100%;
   padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.15);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-foreground) 18%, transparent);
   font-size: 1rem;
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 .auth-card__input:focus {
   outline: none;
-  border-color: rgba(37, 99, 235, 0.6);
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
+  border-color: color-mix(in srgb, var(--color-primary) 65%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .auth-card__error {
-  color: #dc2626;
+  color: var(--color-destructive);
   font-weight: 600;
   margin: 0;
 }
@@ -215,13 +298,17 @@ body {
 .auth-card__submit {
   appearance: none;
   border: none;
-  border-radius: 0.75rem;
+  border-radius: var(--radius-md);
   padding: 0.9rem 1.5rem;
   font-weight: 700;
   font-size: 1rem;
   cursor: pointer;
-  background: linear-gradient(135deg, #1d4ed8, #2563eb);
-  color: #ffffff;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    color-mix(in srgb, var(--color-primary) 85%, black 15%) 100%
+  );
+  color: var(--color-primary-foreground);
   transition:
     transform 150ms ease,
     box-shadow 150ms ease,
@@ -231,7 +318,7 @@ body {
 .auth-card__submit:hover,
 .auth-card__submit:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 15px 30px -15px rgba(37, 99, 235, 0.6);
+  box-shadow: 0 15px 30px -15px color-mix(in srgb, var(--color-primary) 60%, transparent);
 }
 
 .auth-card__submit:disabled {
@@ -251,10 +338,13 @@ body {
 }
 
 .home-card {
-  background-color: #ffffff;
-  border-radius: 1rem;
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
+  border-radius: var(--radius-lg);
   padding: 2rem;
-  box-shadow: 0 15px 40px -20px rgba(15, 23, 42, 0.25);
+  box-shadow:
+    0 15px 40px -20px color-mix(in srgb, var(--color-foreground) 25%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 50%, transparent);
   display: grid;
   gap: 1.5rem;
 }
@@ -277,6 +367,7 @@ body {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.95rem;
+  color: var(--color-muted-foreground);
 }
 
 .home-card__actions {
@@ -288,7 +379,7 @@ body {
 .home-card__result {
   margin: 0;
   font-weight: 600;
-  color: #047857;
+  color: var(--color-success);
 }
 
 .home-news-list {
@@ -306,18 +397,18 @@ body {
 
 .home-news-list__date {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--color-muted-foreground);
 }
 
 .home-news-list__content {
   margin: 0;
   font-weight: 500;
-  color: #0f172a;
+  color: var(--color-foreground);
 }
 
 .home-news-list__empty {
   margin: 0;
-  color: #64748b;
+  color: var(--color-muted-foreground);
 }
 
 .admin {
@@ -332,7 +423,7 @@ body {
 
 .admin__header p {
   margin: 0.5rem 0 0;
-  color: #475569;
+  color: var(--color-muted-foreground);
 }
 
 .admin__layout {
@@ -342,10 +433,13 @@ body {
 }
 
 .admin__form {
-  background-color: #ffffff;
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
   padding: 2rem;
-  border-radius: 1rem;
-  box-shadow: 0 15px 40px -20px rgba(15, 23, 42, 0.25);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 15px 40px -20px color-mix(in srgb, var(--color-foreground) 25%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 50%, transparent);
   display: grid;
   gap: 1rem;
 }
@@ -357,19 +451,22 @@ body {
 
 .admin__label {
   font-weight: 600;
+  color: var(--color-foreground);
 }
 
 .admin__input {
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.15);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-foreground) 18%, transparent);
   padding: 0.75rem 1rem;
   font-size: 1rem;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 .admin__input:focus {
   outline: none;
-  border-color: rgba(30, 64, 175, 0.6);
-  box-shadow: 0 0 0 4px rgba(29, 78, 216, 0.15);
+  border-color: color-mix(in srgb, var(--color-primary) 65%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .admin__checkbox {
@@ -377,12 +474,13 @@ body {
   align-items: center;
   gap: 0.5rem;
   font-weight: 600;
+  color: var(--color-foreground);
 }
 
 .admin__feedback {
   margin: 0;
   font-weight: 600;
-  color: #0f766e;
+  color: var(--color-success);
 }
 
 .admin__actions {
@@ -392,9 +490,12 @@ body {
 
 .admin__table-wrapper {
   overflow-x: auto;
-  background-color: #ffffff;
-  border-radius: 1rem;
-  box-shadow: 0 15px 40px -20px rgba(15, 23, 42, 0.25);
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 15px 40px -20px color-mix(in srgb, var(--color-foreground) 25%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 
 .admin-table {
@@ -405,12 +506,12 @@ body {
 .admin-table th,
 .admin-table td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-foreground) 12%, transparent);
   text-align: left;
 }
 
 .admin-table thead {
-  background-color: rgba(191, 219, 254, 0.4);
+  background-color: color-mix(in srgb, var(--color-secondary) 65%, transparent);
 }
 
 .admin-table__actions {
@@ -430,7 +531,7 @@ body {
 
 .history__header p {
   margin: 0.5rem 0 0;
-  color: #475569;
+  color: var(--color-muted-foreground);
 }
 
 .history__filters {
@@ -438,28 +539,37 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(160px, auto));
   gap: 1rem;
   align-items: end;
-  background-color: #ffffff;
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
   padding: 1.5rem;
-  border-radius: 1rem;
-  box-shadow: 0 15px 40px -20px rgba(15, 23, 42, 0.25);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 15px 40px -20px color-mix(in srgb, var(--color-foreground) 25%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 
 .history__label {
   font-weight: 600;
+  color: var(--color-foreground);
 }
 
 .history__select {
-  border-radius: 0.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.15);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-foreground) 18%, transparent);
   padding: 0.65rem 0.9rem;
   font-size: 1rem;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
 }
 
 .history__table-wrapper {
   overflow-x: auto;
-  background-color: #ffffff;
-  border-radius: 1rem;
-  box-shadow: 0 15px 40px -20px rgba(15, 23, 42, 0.25);
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 15px 40px -20px color-mix(in srgb, var(--color-foreground) 25%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 
 .history-table {
@@ -470,16 +580,16 @@ body {
 .history-table th,
 .history-table td {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-foreground) 12%, transparent);
   text-align: left;
 }
 
 .history-table thead {
-  background-color: rgba(226, 232, 240, 0.65);
+  background-color: color-mix(in srgb, var(--color-secondary) 60%, transparent);
 }
 
 .history-table__empty {
   text-align: center;
   padding: 2rem 1rem;
-  color: #64748b;
+  color: var(--color-muted-foreground);
 }


### PR DESCRIPTION
## Summary
- reintroduce the auth, home, admin, and history layout classes while mapping their colors and shadows onto the new theme tokens
- add success color tokens so positive state indicators remain legible in both light and dark modes

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e61544b5648322834273ddce9d1a83